### PR TITLE
Removing duplicate description of '>'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1509,11 +1509,6 @@
                             <td>used for sending output to a file and erasing any previous content in that file.
                             </td>
                         </tr>
-                        <tr>
-                            <td><code>&gt;</code></td>
-                            <td>used for sending output to a file and erasing any previous content in that file.
-                            </td>
-                        </tr>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
The row above has the same symbol and description